### PR TITLE
feat: switch from using coords to geocoding addresses for sure sites

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 deploy/
 dist/
 node_modules/
+scripts/geocoding_cache.json
 scripts/Logs/
 scripts/settings_ib/__init__.py
 secrets.json

--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,8 @@
     "esri": "arcgis-js-api#~3.18.0",
     "jquery": "jquery#~2.2.0",
     "sherlock": "agrc-sherlock#~1.1.0",
-    "proj4": "2.3.17"
+    "proj4": "2.3.17",
+    "dijit-themes": "https://github.com/dojo/dijit-themes.git#1.14.0"
   },
   "resolutions": {
     "esri": "~3.18.0",
@@ -29,7 +30,6 @@
     "dojox": "v1.11.2/esri-3.18.0",
     "util": "v1.11.2/esri-3.18.0",
     "spinjs": "~2.3.2",
-    "moment": "~2.14",
-    "dojo-themes": "~1.11"
+    "moment": "~2.14"
   }
 }

--- a/scripts/geocoding.py
+++ b/scripts/geocoding.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python
+# * coding: utf8 *
+'''
+geocoding.py
+
+A module for geocoding addresses via AGRC's web api
+'''
+
+import requests
+import time
+import random
+import json
+from os.path import abspath, dirname, join, exists
+
+
+def api_retry(api_call):
+    """Retry and api call if calling method returns None."""
+    def retry(*args, **kwargs):
+        response = api_call(*args, **kwargs)
+        back_off = 1
+        while response is None and back_off <= 8:
+            time.sleep(back_off + random.random())
+            response = api_call(*args, **kwargs)
+            back_off += back_off
+        return response
+    return retry
+
+
+class NotFoundException(Exception):
+    pass
+
+
+class Geocoder(object):
+    _api_key = None
+    _url_template = "http://api.mapserv.utah.gov/api/v1/geocode/{}/{}"
+    _cache_results = False
+    _cache_file_path = None
+    _output_spatial_reference = None
+    _cache = None
+
+    def __init__(self, api_key, cache_results=False, output_spatial_reference=3857):
+        self._api_key = api_key
+        self._cache_results = cache_results
+        self._output_spatial_reference = output_spatial_reference
+
+        if cache_results:
+            self._initialize_cache()
+
+    def _initialize_cache(self):
+        current_directory = abspath(dirname(__file__))
+        self._cache_file_path = join(current_directory, 'geocoding_cache.json')
+
+        if exists(self._cache_file_path):
+            with open(self._cache_file_path, 'r') as file:
+                self._cache = json.load(file)
+        else:
+            self._cache = {}
+
+    @api_retry
+    def locate(self, street, zone, **kwargs):
+        cache_key = '{}, {}'.format(street, zone)
+        if self._cache_results and cache_key in self._cache:
+            return self._cache[cache_key]
+
+        kwargs['apiKey'] = self._api_key
+        kwargs['spatialReference'] = self._output_spatial_reference
+
+        try:
+            response = requests.get(self._url_template.format(street, zone), params=kwargs)
+            response_json = response.json()
+        except Exception:
+            #: return None so that api_retry will try it again
+            return None
+
+        if response.status_code is not 200 or response_json['status'] is not 200:
+            msg = '{}, {} was not found. {}'.format(street, zone, response_json['message'])
+            print(msg)
+
+            raise NotFoundException(msg)
+
+        if self._cache_results:
+            self._cache[cache_key] = response_json['result']
+
+        #: result props: score, matchAddress, location
+        return response_json['result']
+
+    def __del__(self):
+        if self._cache_results:
+            with open(self._cache_file_path, 'w') as file:
+                json.dump(self._cache, file)

--- a/scripts/settings_ib/__init__.sample.py
+++ b/scripts/settings_ib/__init__.sample.py
@@ -1,0 +1,52 @@
+DATA_PATH = r'C:\MapData'
+API_KEY = '<server api key>'
+
+
+FIBER_GDB = DATA_PATH + r'\fiberverification.gdb'
+HEXAGONS = FIBER_GDB + r'\Hexagons'
+SERVICE_AREAS = FIBER_GDB + r'\ProviderServiceAreas'
+BB_GDB = DATA_PATH + r'\broadband.gdb'
+PROVIDERS = BB_GDB + r'\BB_Providers_Table'
+FIXED = BB_GDB + r'\BB_Service'
+
+UTILITIES_GDB = DATA_PATH + r'\utilities.gdb'
+NATURAL_GAS = UTILITIES_GDB + r'\NaturalGasService_Approx'
+ELECTRICAL = UTILITIES_GDB + r'\ElectricalService'
+RURAL_TEL = UTILITIES_GDB + r'\RuralTelcomBoundaries'
+ROADS = BB_GDB + r'\RoadsBuffer'
+ENTERPRISE_ZONES = DATA_PATH + r'\economy.gdb\EnterpriseZones'
+TAX_ENTITIES = DATA_PATH + r'\bbecon.gdb\TaxEntities2017'
+
+BBECON_GDB = DATA_PATH + r'\bbecon-static.gdb'
+OPPORTUNITY_ZONES = BBECON_GDB + r'\OpportunityZones'
+AIRPORT_INT = BBECON_GDB + r'\Airport_SLinternational_DriveTime'
+AIRPORT_REG = BBECON_GDB + r'\Airport_RegionalCommercial_DriveTime'
+AIRPORT_LOCAL = BBECON_GDB + r'\Airport_Local_DriveTime'
+COUNTIES = BBECON_GDB + r'\CountyDemographics'
+POLYGON_DATA = DATA_PATH + r'\bbecon.gdb' + r'\PolygonData'
+
+SCHOOLS = BBECON_GDB + r'\HigherEd_DriveTime'
+NAT_PARKS = BBECON_GDB + r'\NatlParks_DriveTime'
+STATE_PARKS = BBECON_GDB + r'\StParksAndMonuments_DriveTime'
+SKI = BBECON_GDB + r'\SkiArea_DriveTime'
+GOLF = BBECON_GDB + r'\GolfCourses_DriveTime'
+
+FIBER_TERMS = {1: 'Short term (1-3 month avg)', 9: 'Custom order (3-9 month avg)'}
+
+DATASETS = ['Hexagons',
+            'BB_Service',
+            'ElectricalService',
+            'RuralTelcomBoundaries',
+            'NaturalGasService_Approx',
+            'Airport_SLinternational_DriveTime',
+            'Airport_RegionalCommercial_DriveTime',
+            'Airport_Local_DriveTime',
+            'HigherEd_DriveTime',
+            'CountyDemographics',
+            'EnterpriseZones',
+            'NatlParks_DriveTime',
+            'StParksAndMonuments_DriveTime',
+            'SkiArea_DriveTime',
+            'RoadsBuffer',
+            'TaxEntities2017',
+            'OpportunityZones']


### PR DESCRIPTION
If the address doesn't geocode, it falls back to coords.

This was in response to complaints from edcUtah saying that locate.utah.gov was not showing the same data as their site.